### PR TITLE
fix(ui): Hide the Unassociated applications by default if empty

### DIFF
--- a/src/app/components/applications/applications-view.html
+++ b/src/app/components/applications/applications-view.html
@@ -12,7 +12,7 @@
 		<div data-uib-accordion-group
 		 	data-ng-show="model.unlinkedDevices.has"
 			class="panel-default"
-			data-is-open="model.unlinkedDevices.open">
+			data-is-open="model.unlinkedDevices.open" data-ng-if="model.devices.availableDevices.size > 0">
 			<div data-uib-accordion-heading>
 				<div data-ng-click="selectApplication()">
 					<span>Unassociated applications</span>


### PR DESCRIPTION
Fix bug : https://github.com/denouche/iot-admin-front/issues/1